### PR TITLE
make mif run under recent setuptools and python3.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
     - name: "Python 3.8 Tests"
       python: "3.8"
       env: TOXENV=py38
+    - name: "Python 3.12 Tests"
+      python: "3.12"
+      env: TOXENV=py312
 
     - name: "Lint and Code Style"
       python: "3.7"

--- a/mif/__init__.py
+++ b/mif/__init__.py
@@ -1,11 +1,9 @@
 import io
 import math
 
+import importlib_resources
 import lark
-
 import numpy
-
-import pkg_resources
 
 
 class MIFError(Exception):
@@ -52,7 +50,8 @@ class ParseTransformer(lark.Transformer):
 
 class Loader:
     # find and load our grammar
-    with pkg_resources.resource_stream(__name__, 'grammar.bnf') as f:
+    path = importlib_resources.files(__name__) / 'grammar.bnf'
+    with open(path, 'rb') as f:
         parser = lark.Lark(
             io.TextIOWrapper(f),
             start='file',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
 
     setup_requires=[
         'setuptools_git >= 0.3',
-        'better-setuptools-git-version >= 1.0',
+        'bad-setuptools-git-version >= 1.0.12',
     ],
     extras_require={
         'docs': ['mkdocs >= 1.0, < 1.1', 'mkautodoc >= 0.1.0'],

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
     install_requires=[
         'numpy >= 1.17.0',
         'lark-parser >= 0.8.0',
+        'importlib-resources >= 6.5.2'
     ],
     python_requires='>=3.5',
     include_package_data=True,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,17 +1,15 @@
-import io
-import os.path
 import unittest
+
+import importlib_resources
 
 import mif
 
-import pkg_resources
 
 RADIXES = ['BIN', 'HEX', 'OCT', 'DEC', 'UNS']
 
 
-def load_data(n):
-    p = os.path.join('data', n)
-    return io.TextIOWrapper(pkg_resources.resource_stream(__name__, p))
+def get_data_path(n):
+    return importlib_resources.files(__name__) / 'data' / n
 
 
 class TestPacked(unittest.TestCase):
@@ -33,7 +31,7 @@ class TestPacked(unittest.TestCase):
 
 class TestLoadDump(unittest.TestCase):
     def test_parse(self):
-        with load_data('example.mif') as f:
+        with open(get_data_path('example.mif')) as f:
             mem = mif.load(f)
         for i, v in enumerate(mem):
             expected = '00000000'
@@ -43,7 +41,7 @@ class TestLoadDump(unittest.TestCase):
             self.assertEqual(expected, val)
 
     def test_round_trip(self):
-        with load_data('example.mif') as f:
+        with open(get_data_path('example.mif')) as f:
             mem = mif.load(f)
         memlist = [list(m) for m in mem]
         for a in RADIXES:
@@ -55,7 +53,7 @@ class TestLoadDump(unittest.TestCase):
 
 class TestLoadDumpWide(unittest.TestCase):
     def test_parse(self):
-        with load_data('example-wide.mif') as f:
+        with open(get_data_path('example-wide.mif')) as f:
             mem = mif.load(f)
         expected_blob = [
             '1000000100111111001000000001000000001000000001000000001000000001',
@@ -67,7 +65,7 @@ class TestLoadDumpWide(unittest.TestCase):
         self.assertEqual(list(mem[0]), expected)
 
     def test_round_trip(self):
-        with load_data('example-wide.mif') as f:
+        with open(get_data_path('example-wide.mif')) as f:
             mem = mif.load(f)
         memlist = [list(m) for m in mem]
         for a in RADIXES:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.3.1
-envlist = py35,py36,py37,py38,lint,docs,build
+envlist = py35,py36,py37,py38,py312,lint,docs,build
 
 [testenv]
 commands = python -m tests


### PR DESCRIPTION
when using mif in a recent environment, a lot of deprecation warnings are thrown because of the usage of pkg_resources, which will not be in setuptool>80, coming in November.
this is fixed by not using it anymore. also minor changes in setup.py to allow building under python~3.12. 
tests on my local machine were successfully.