### PR TITLE
use lark instead of lark-parser as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     packages=find_packages(exclude=['tests', 'tests.*']),
     install_requires=[
         'numpy >= 1.17.0',
-        'lark-parser >= 0.8.0',
+        'lark >= 0.12.0',
         'importlib-resources >= 5.12, < 6.0',
     ],
     python_requires='>=3.5',


### PR DESCRIPTION
the lark-parser changed it's name to lark upstream. to get more recent versions, use the new name. lark-parser 0.8 also has deprecation warnings.