### PR TITLE
remove importlib_resources dependency and use importlib.resources

### DIFF
--- a/mif/__init__.py
+++ b/mif/__init__.py
@@ -1,7 +1,7 @@
+import importlib.resources
 import io
 import math
 
-import importlib_resources
 
 import lark
 
@@ -52,7 +52,7 @@ class ParseTransformer(lark.Transformer):
 
 class Loader:
     # find and load our grammar
-    _grammar_path = importlib_resources.files(__name__) / 'grammar.bnf'
+    _grammar_path = importlib.resources.files(__name__) / 'grammar.bnf'
     with _grammar_path.open() as f:
         parser = lark.Lark(
             f,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ requires-python = '>= 3.9'
 dependencies = [
     'numpy >= 1.17.0',
     'lark >= 0.12.0',
-    'importlib-resources >= 5.12, < 6.0',
 ]
 
 [project.optional-dependencies]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,5 @@
+import importlib.resources
 import unittest
-
-import importlib_resources
 
 import mif
 
@@ -9,7 +8,7 @@ RADIXES = ['BIN', 'HEX', 'OCT', 'DEC', 'UNS']
 
 
 def get_data_path(n):
-    return importlib_resources.files(__name__) / 'data' / n
+    return importlib.resources.files(__name__) / 'data' / n
 
 
 class TestPacked(unittest.TestCase):


### PR DESCRIPTION
mif requires python>=3.9 and importlib.resources is integrated in python>=3.7, so we don't need the backport anymore